### PR TITLE
Added versions of collaborators that handle Owner and Repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,42 @@ remove_collaborator(owner, repo, user; auth = AnonymousAuth())
 - `repo` is a repository name
 - `user` is the GitHub login being inspected, added, or removed
 
+#### Examples
+```julia
+julia> using GitHub
+
+julia> collaborators("JuliaLang","Julia")
+26-element Array{Any,1}:
+ User - amitmurthy
+ User - andreasnoackjensen
+ ⋮
+ User - tshort
+ User - vtjnash
+
+julia> o = org("JuliaLang")
+User - JuliaLang (The Julia Language, http://julialang.org/)
+
+julia> collaborators(o,"julia")
+26-element Array{Any,1}:
+ User - amitmurthy
+ User - andreasnoackjensen
+ ⋮
+ User - tshort
+ User - vtjnash
+
+julia> r = repo("JuliaLang","julia")
+Repo - JuliaLang/julia (http://julialang.org/)
+"The Julia Language: A fresh approach to technical computing."
+
+julia> collaborators(r)
+26-element Array{Any,1}:
+ User - amitmurthy
+ User - andreasnoackjensen
+ ⋮
+ User - tshort
+ User - vtjnash
+```
+
 
 ### Issues
 

--- a/src/collaborators.jl
+++ b/src/collaborators.jl
@@ -1,6 +1,14 @@
 
 # Interface -------
 
+function collaborators(repo::Repo; auth = AnonymousAuth(), options...)
+    collaborators(auth, repo.owner.login, repo.name; options...)
+end
+
+function collaborators(owner::Owner, repo; auth = AnonymousAuth(), options...)
+    collaborators(auth, owner.login, repo; options...)
+end
+
 function collaborators(owner, repo; auth = AnonymousAuth(), options...)
     collaborators(auth, owner, repo; options...)
 end


### PR DESCRIPTION
Many functions seem to only support strings as arguments. This seems unfortunate, since those strings could be extracted from a Repo or Owner automatically. Is this something you want the API to support?

I also added usage examples to Collaborators section of the README.
