### PR TITLE
Support Links pagination header in repos function.

### DIFF
--- a/src/repos.jl
+++ b/src/repos.jl
@@ -115,5 +115,16 @@ function repos(auth::Authorization, owner; typ = nothing, # for user: all, membe
 
   handle_error(r)
 
-  Repo[Repo(d) for d in JSON.parse(r.data)]
+  # Handle Pagination Links
+  results = JSON.parse(r.data)
+  links = parse_link_header(r.headers["Link"])
+  while haskey(links,"next")
+    r = get(links["next"])
+    handle_error(r)
+
+    append!(results,JSON.parse(r.data))
+    links = parse_link_header(r.headers["Link"])
+  end
+
+  Repo[Repo(d) for d in results]
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,3 +10,12 @@ function github_obj_from_type(data::Dict)
         return Organization(data)
     end
 end
+
+function parse_link_header(s::String)
+  results = Dict{String,URI}()
+  # <url>; rel="name", <url2>; rel="name2", ...
+  for m in eachmatch(r"<([^>]+)>; rel=\"(\w+)\",? ?", s)
+    results[m.captures[2]] = URI(m.captures[1])
+  end
+  return results
+end


### PR DESCRIPTION
GitHub uses the `Link` header to provide links to other "pages" of results. I've modified the `repos` function to really return all the results for a given user/org.

This should probably be some kind of an option for the functions in general, to pick whether to return 1 page of results or all the results. Pagination is annoying to do by hand, and can be pretty easily integrated into the Array-returning functions.
