### PR TITLE
Added Pagination to relevant functions

### DIFF
--- a/src/collaborators.jl
+++ b/src/collaborators.jl
@@ -5,16 +5,13 @@ function collaborators(owner, repo; auth = AnonymousAuth(), options...)
     collaborators(auth, owner, repo; options...)
 end
 
-function collaborators(auth::Authorization, owner, repo; headers = Dict(), options...)
+function collaborators(auth::Authorization, owner, repo; result_limit = -1, headers = Dict(), options...)
     authenticate_headers(headers, auth)
-    r = get(URI(API_ENDPOINT; path = "/repos/$owner/$repo/collaborators");
-            headers = headers,
-            options...)
-
-    handle_error(r)
-
-    data = JSON.parse(r.data)
-    map!( u -> User(u), data)
+    pages = get_pages(URI(API_ENDPOINT; path = "/repos/$owner/$repo/collaborators"), result_limit;
+                      headers = headers,
+                      options...)
+    items = get_items_from_pages(pages)
+    return User[User(i) for i in items]
 end
 
 

--- a/src/forks.jl
+++ b/src/forks.jl
@@ -5,16 +5,13 @@ function forks(owner, repo; auth = AnonymousAuth(), options...)
     forks(auth, owner, repo; options...)
 end
 
-function forks(auth, owner, repo; headers = Dict(), options...)
+function forks(auth, owner, repo; headers = Dict(), result_limit = -1, options...)
     authenticate_headers(headers, auth)
-    r = get(URI(API_ENDPOINT; path = "/repos/$owner/$repo/forks");
-            headers = headers,
-            options...)
-
-    handle_error(r)
-
-    data = JSON.parse(r.data)
-    map!( r -> Repo(r), data)
+    pages = get_pages(URI(API_ENDPOINT; path = "/repos/$owner/$repo/forks"), result_limit;
+                      headers = headers,
+                      options...)
+    items = get_items_from_pages(pages)
+    return Repo[Repo(i) for i in items]
 end
 
 

--- a/src/organizations.jl
+++ b/src/organizations.jl
@@ -103,13 +103,11 @@ function orgs(user::User; auth = AnonymousAuth(), options...)
     orgs(auth, user.login; options...)
 end
 
-function orgs(auth::Authorization, user; headers = Dict(), options...)
+function orgs(auth::Authorization, user; headers = Dict(), result_limit = -1, options...)
     authenticate_headers(headers, auth)
-    r = get(URI(API_ENDPOINT; path = "/users/$user/orgs");
-            headers = headers,
-            options...)
-
-    handle_error(r)
-
-    map!(o -> Organization(o), JSON.parse(r.data))
+    pages = get_pages(URI(API_ENDPOINT; path = "/users/$user/orgs"), result_limit;
+                      headers = headers,
+                      options...)
+    items = get_items_from_pages(pages)
+    return Organization[Organization(i) for i in items]
 end

--- a/src/repos.jl
+++ b/src/repos.jl
@@ -103,14 +103,14 @@ function repos(auth::Authorization, owner; typ = nothing, # for user: all, membe
                                            data = Dict(),
                                            result_limit = -1,
                                            options...)
-  authenticate_headers(headers, auth)
+    authenticate_headers(headers, auth)
 
-  typ == nothing || (data["type"] = typ)
-  sort == nothing || (data["sort"] = sort)
-  direction == nothing || (data["direction"] = direction)
+    typ == nothing || (data["type"] = typ)
+    sort == nothing || (data["sort"] = sort)
+    direction == nothing || (data["direction"] = direction)
 
-  pages = get_pages(URI(API_ENDPOINT; path = "$owner/repos"), result_limit;
-                headers = headers, query = data, options...)
-  items = get_items_from_pages(pages)
-  return Repo[Repo(d) for d in items]
+    pages = get_pages(URI(API_ENDPOINT; path = "$owner/repos"), result_limit;
+                      headers = headers, query = data, options...)
+    items = get_items_from_pages(pages)
+    return Repo[Repo(d) for d in items]
 end

--- a/src/users.jl
+++ b/src/users.jl
@@ -106,15 +106,13 @@ function followers(user::User; auth = AnonymousAuth(), options...)
     followers(auth, user.login; options...)
 end
 
-function followers(auth::Authorization, user; headers = Dict(), options...)
+function followers(auth::Authorization, user; headers = Dict(), result_limit = -1, options...)
     authenticate_headers(headers, auth)
-    r = get(URI(API_ENDPOINT; path = "/users/$user/followers");
-            headers = headers,
-            options...)
-
-    handle_error(r)
-
-    map!(f -> User(f), JSON.parse(r.data))
+    pages = get_pages(URI(API_ENDPOINT; path = "/users/$user/followers"), result_limit;
+                  headers = headers,
+                  options...)
+    items = get_items_from_pages(pages)
+    return User[User(i) for i in items]
 end
 
 
@@ -126,13 +124,11 @@ function following(user::User; auth = AnonymousAuth(), options...)
     following(auth, user.login; options...)
 end
 
-function following(auth::Authorization, user; headers = Dict(), options...)
+function following(auth::Authorization, user; headers = Dict(), result_limit = -1, options...)
     authenticate_headers(headers, auth)
-    r = get(URI(API_ENDPOINT; path = "/users/$user/following");
-            headers = headers,
-            options...)
-
-    handle_error(r)
-
-    map!(f -> User(f), JSON.parse(r.data))
+    pages = get_pages(URI(API_ENDPOINT; path = "/users/$user/following"), result_limit;
+                      headers = headers,
+                      options...)
+    items = get_items_from_pages(pages)
+    return User[User(i) for i in items]
 end

--- a/src/watching.jl
+++ b/src/watching.jl
@@ -5,16 +5,13 @@ function watchers(owner, repo; auth = AnonymousAuth(), options...)
     watchers(auth, owner, repo; options...)
 end
 
-function watchers(auth::Authorization, owner, repo; headers = Dict(), options...)
+function watchers(auth::Authorization, owner, repo; headers = Dict(), result_limit = -1, options...)
     authenticate_headers(headers, auth)
-    r = get(URI(API_ENDPOINT; path = "/repos/$owner/$repo/subscribers");
+    pages = get_pages(URI(API_ENDPOINT; path = "/repos/$owner/$repo/subscribers"), result_limit;
             headers = headers,
             options...)
-
-    handle_error(r)
-
-    data = JSON.parse(r.data)
-    map!( u -> User(u), data)
+    items = get_items_from_pages(pages)
+    return User[User(i) for i in items]
 end
 
 
@@ -22,14 +19,13 @@ function watched(user; auth = AnonymousAuth(), options...)
     watched(auth, user; options...)
 end
 
-function watched(auth::Authorization, user; headers = Dict(), options...)
+function watched(auth::Authorization, user; headers = Dict(), result_limit = -1, options...)
     authenticate_headers(headers, auth)
-    r = get(URI(API_ENDPOINT; path = "/users/$user/subscriptions"); headers = headers,
-                                                                    options...)
-    handle_error(r)
-
-    data = JSON.parse(r.data)
-    map!( r -> Repo(r), data)
+    pages = get_pages(URI(API_ENDPOINT; path = "/users/$user/subscriptions"), result_limit;
+                      headers = headers,
+                      options...)
+    items = get_items_from_pages(pages)
+    return Repo[Repo(i) for i in items]
 end
 
 


### PR DESCRIPTION
- Added some helper functions in utils
- Called helper functions from:
  - followers
  - following
  - orgs
  - issues
  - collaborators
  - repos
  - watchers
  - watched
  - forks
  - starred
  - stargazers
- Called all those functions to make sure they still work. Having unit tests would be helpful.

The helper functions take care of making all the `get` calls. It re-uses the headers to make sure that authenticated requests are all authenticated. `stargazers` handles a `per_page` argument; all of the functions handle a `result_limit` argument.

By default, all results are returned. If `result_limit` is set, then pages are read until either we run out of pages or we think we've reached/exceeded the result limit. Since the default page size is 30, this means that `result_limit=20` will produce 30 results, and `result_limit=100` will produce 120 (if there are that many).
