### PR TITLE
Query All Users API and Pagination

### DIFF
--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -42,6 +42,7 @@ export # owners.jl
        Owner,
        owner,
        orgs,
+       users,
        followers,
        following,
        repos

--- a/src/owners/owners.jl
+++ b/src/owners/owners.jl
@@ -50,6 +50,11 @@ function owner(owner_obj, isorg = false; options...)
     return Owner(result)
 end
 
+function users(; options...)
+    results, page_data = gh_get_paged_json("/users"; options...)
+    return map(Owner, results), page_data
+end
+
 function orgs(owner; options...)
     results, page_data = gh_get_paged_json("/users/$(name(owner))/orgs"; options...)
     return map(Owner, results), page_data


### PR DESCRIPTION
There are two things added in this pull request:

1. An API to query all users.
2. Better pagination support by directly returning next_page and last_page URL.

According to [GitHub](https://developer.github.com/v3/#link-header), it's better to follow the Link header rather than constructing URLs ourselves. For example, `/users` API always return next page link and previous page link using `since` rather than `page`. Thus it becomes impossible to get page number and page left, etc.

This is my first pull request to a Julia project, so please tell me if I got anything wrong.