### PR TITLE
Allow link headers returned from paged requests to used in new requests

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.4
 
+Compat
 JSON
 HttpServer
 MbedTLS

--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -1,5 +1,7 @@
 module GitHub
 
+using Compat
+
 ##########
 # import #
 ##########


### PR DESCRIPTION
This PR is a follow-up to discussion in #49. 