### PR TITLE
use dirname(@__FILE__) rather than Pkg.dir

### DIFF
--- a/test/event_tests.jl
+++ b/test/event_tests.jl
@@ -1,7 +1,7 @@
 using GitHub
 using Base.Test
 
-event_request = open(joinpath(Pkg.dir("GitHub"), "test", "commit_comment.jls"), "r") do file
+event_request = open(joinpath(dirname(@__FILE__), "commit_comment.jls"), "r") do file
     return Base.deserialize(file)
 end
 event_json = Requests.json(event_request)


### PR DESCRIPTION
this allows tests to work even when installed in a different location