### PR TITLE
Fix `apps` test

### DIFF
--- a/src/apps/apps.jl
+++ b/src/apps/apps.jl
@@ -5,8 +5,6 @@ type App <: GitHubType
     description::Nullable{String}
     external_url::Nullable{String}
     html_url::Nullable{String}
-    created_at::Nullable{Dates.DateTime}
-    updated_at::Nullable{Dates.DateTime}
 end
 
 namefield(a::App) = a.id

--- a/test/read_only_api_tests.jl
+++ b/test/read_only_api_tests.jl
@@ -132,6 +132,6 @@ end
 end
 
 @testset "Apps" begin
-    @test get(app(4123).name) == "femtocleaner"
-    @test get(app("femtocleaner").name) == "femtocleaner"
+    @test get(app(4123; auth=auth).name) == "femtocleaner"
+    @test get(app("femtocleaner"; auth=auth).name) == "femtocleaner"
 end


### PR DESCRIPTION
Also get rid of the timestamps from the App type. They have time zone information (now,
they didn't a few days ago when I wrote the code for the first time),
which we currently don't handle. I played with TimeZones.jl, but it currently can't
parse the GitHub time stamp. For now, just delete those fields and revisit that
once TimeZones.jl has been updated to handle this better.