### PR TITLE
Enable precompilation

### DIFF
--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module GitHub
 
 using Compat


### PR DESCRIPTION
It appears that all dependencies allow precompilation, so this should be safe. It would also allow Nanosoldier to precompile, as GitHub is its only dependency that isn't precompilable.