### PR TITLE
Return 204 instead of 400 for invalid events

### DIFF
--- a/src/activity/events.jl
+++ b/src/activity/events.jl
@@ -102,7 +102,7 @@ function handle_event_request(request, handle;
     end
 
     if !(isa(events, Void)) && !(is_valid_event(request, events))
-        return HTTP.Response(400, "invalid event")
+        return HTTP.Response(204, "event ignored")
     end
 
     event = event_from_payload!(event_header(request), JSON.parse(String(request)))


### PR DESCRIPTION
As suggested by Jarrett. Currently we give 400 for events we identify as "invalid." These have either no header or the header doesn't match one of the given event types. The former case is clearly more suited for 204: No Content. The latter case is less clear, but a client error doesn't seem appropriate. Thus this PR changes the response to 204.