### PR TITLE
[WIP] Updates for new HTTP.jl tag

### DIFF
--- a/test/event_tests.jl
+++ b/test/event_tests.jl
@@ -1,6 +1,6 @@
 include("commit_comment.jl")
 event_request = create_event()
-event_json = JSON.parse(String(event_request))
+event_json = JSON.parse(String(event_request.body))
 event = GitHub.event_from_payload!("commit_comment", event_json)
 
 @testset "WebhookEvent" begin


### PR DESCRIPTION
Pending a new tag of HTTP.jl, here are a few changes that will be needed. This doesn't quite pass all 0.6 tests, but it's pretty close. Something was failing w/ the `pull_requests` call only returning 3 PRs instead of all. I'll have to look more into it. (note my results were against current HTTP.jl master)