### PR TITLE
More verbose error printing if the body is not JSON

### DIFF
--- a/src/utils/requests.jl
+++ b/src/utils/requests.jl
@@ -147,16 +147,19 @@ end
 function handle_response_error(r::HTTP.Response)
     if r.status >= 400
         message, docs_url, errors = "", "", ""
+        body = HTTP.load(r)
         try
-            data = JSON.parse(HTTP.load(r))
+            data = JSON.parse(body)
             message = get(data, "message", "")
             docs_url = get(data, "documentation_url", "")
             errors = get(data, "errors", "")
         end
         error("Error found in GitHub reponse:\n",
               "\tStatus Code: $(r.status)\n",
-              "\tMessage: $message\n",
-              "\tDocs URL: $docs_url\n",
-              "\tErrors: $errors")
+              ((isempty(message) && isempty(errors)) ?
+               ("\tBody: $body",) :
+               ("\tMessage: $message\n",
+                "\tDocs URL: $docs_url\n",
+                "\tErrors: $errors"))...)
     end
 end


### PR DESCRIPTION
Recently could have saved me a bunch of time when GitHub
returned an authorization error, which does not follow
the usual JSON format.