### PR TITLE
Use HTTP.payload instead of HTTP.load

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,6 +3,6 @@ julia 0.6
 Compat 0.43
 JSON
 MbedTLS
-HTTP 0.6
+HTTP 0.6.3
 Nullables
 

--- a/src/activity/events.jl
+++ b/src/activity/events.jl
@@ -43,7 +43,7 @@ sig_header(request::HTTP.Request) = HTTP.header(request, "X-Hub-Signature")
 
 function has_valid_secret(request::HTTP.Request, secret)
     if has_sig_header(request)
-        secret_sha = "sha1="*bytes2hex(MbedTLS.digest(MbedTLS.MD_SHA1, HTTP.load(request), secret))
+        secret_sha = "sha1="*bytes2hex(MbedTLS.digest(MbedTLS.MD_SHA1, HTTP.payload(request, String), secret))
         return sig_header(request) == secret_sha
     end
     return false
@@ -97,7 +97,7 @@ function handle_event_request(request, handle;
         return HTTP.Response(204, "event ignored")
     end
 
-    event = event_from_payload!(event_header(request), JSON.parse(HTTP.load(request)))
+    event = event_from_payload!(event_header(request), JSON.parse(HTTP.payload(request, String)))
 
     if !(isa(repos, Nothing)) && !(from_valid_repo(event, repos))
         return HTTP.Response(400, "invalid repo")

--- a/src/apps/installations.jl
+++ b/src/apps/installations.jl
@@ -25,5 +25,5 @@ end
     headers["Accept"] = "application/vnd.github.machine-man-preview+json"
     results, page_data = github_paged_get(api, "/installation/repositories";
         headers=headers, options...)
-    mapreduce(x->map(Repo, JSON.parse(HTTP.load(x))["repositories"]), vcat, Repo[], results), page_data
+    mapreduce(x->map(Repo, JSON.parse(HTTP.payload(x, String))["repositories"]), vcat, Repo[], results), page_data
 end

--- a/src/utils/requests.jl
+++ b/src/utils/requests.jl
@@ -70,11 +70,11 @@ gh_put(api::GitHubAPI, endpoint = ""; options...) = github_request(api, HTTP.put
 gh_delete(api::GitHubAPI, endpoint = ""; options...) = github_request(api, HTTP.delete, endpoint; options...)
 gh_patch(api::GitHubAPI, endpoint = ""; options...) = github_request(api, HTTP.patch, endpoint; options...)
 
-gh_get_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.load((gh_get(api, endpoint; options...))))
-gh_post_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.load((gh_post(api, endpoint; options...))))
-gh_put_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.load((gh_put(api, endpoint; options...))))
-gh_delete_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.load((gh_delete(api, endpoint; options...))))
-gh_patch_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.load((gh_patch(api, endpoint; options...))))
+gh_get_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.payload(gh_get(api, endpoint; options...), String))
+gh_post_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.payload(gh_post(api, endpoint; options...), String))
+gh_put_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.payload(gh_put(api, endpoint; options...), String))
+gh_delete_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.payload(gh_delete(api, endpoint; options...), String))
+gh_patch_json(api::GitHubAPI, endpoint = ""; options...) = JSON.parse(HTTP.payload(gh_patch(api, endpoint; options...), String))
 
 #################
 # Rate Limiting #
@@ -137,7 +137,7 @@ end
 
 function gh_get_paged_json(api, endpoint = ""; options...)
     results, page_data = github_paged_get(api, endpoint; options...)
-    return mapreduce(r -> JSON.parse(HTTP.load(r)), vcat, results), page_data
+    return mapreduce(r -> JSON.parse(HTTP.payload(r, String)), vcat, results), page_data
 end
 
 ##################
@@ -147,7 +147,7 @@ end
 function handle_response_error(r::HTTP.Response)
     if r.status >= 400
         message, docs_url, errors = "", "", ""
-        body = HTTP.load(r)
+        body = HTTP.payload(r, String)
         try
             data = JSON.parse(body)
             message = get(data, "message", "")

--- a/test/event_tests.jl
+++ b/test/event_tests.jl
@@ -1,6 +1,6 @@
 include("commit_comment.jl")
 event_request = create_event()
-event_json = JSON.parse(HTTP.load(event_request))
+event_json = JSON.parse(HTTP.payload(event_request, String))
 event = GitHub.event_from_payload!("commit_comment", event_json)
 
 @testset "WebhookEvent" begin


### PR DESCRIPTION
`HTTP.load` is deprecated as of HTTP 0.6.3.