### PR TITLE
Bugfix to tag

### DIFF
--- a/src/git/tag.jl
+++ b/src/git/tag.jl
@@ -12,7 +12,7 @@ Tag(data::Dict) = json2github(Tag, data)
 namefield(tag::Tag) = tag.sha
 
 @api_default function tag(api::GitHubAPI, repo, tag_obj; options...)
-    result = gh_get_json(api, "/repos/$(name(repo))/git/tags/$(name(tag_obj))"; options...)
+    result = gh_get_json(api, "/repos/$(name(repo))/git/refs/tags/$(name(tag_obj))"; options...)
     return Tag(result)
 end
 


### PR DESCRIPTION
It shouldn't be querying `/git/tags`, but rather `/git/refs/tags`. (There is an API endpoint `/git/tags`, but that only accepts SHA1 hashes). 