### PR TITLE
setup HTTP listener correctly for new HTTP.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,5 +3,5 @@ julia 0.7.0-rc3
 Compat 0.62
 JSON
 MbedTLS
-HTTP 0.6.3
+HTTP 0.8.0
 

--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -11,7 +11,8 @@ using Base64
 
 import HTTP,
        JSON,
-       MbedTLS
+       MbedTLS,
+       Sockets
 
 ########
 # init #

--- a/src/activity/events.jl
+++ b/src/activity/events.jl
@@ -123,7 +123,12 @@ function Base.run(listener::EventListener, host::HTTP.IPAddr, port::Int, args...
     println("Listening for GitHub events sent to $port;")
     println("Whitelisted events: $(isa(listener.events, Nothing) ? "All" : listener.events)")
     println("Whitelisted repos: $(isa(listener.repos, Nothing) ? "All" : listener.repos)")
-    HTTP.listen(listener.handle_request, host, port; kwargs...)
+    sock = Sockets.listen(Sockets.InetAddr(host, port))
+    run(listener, sock, host, port, args...; kwargs...)
+end
+
+function Base.run(listener::EventListener, sock::Sockets.TCPServer, host::HTTP.IPAddr, port::Int, args...; kwargs...)
+    HTTP.serve(listener.handle_request, host, port; server=sock, kwargs...)
 end
 
 ###################


### PR DESCRIPTION
- use HTTP.serve instead of HTTP.listen (fixes #125)
- have a way to stop the HTTP server via new run method that takes a listen socket
- add tests for one complete HTTP request-response cycle