### PR TITLE
Define Content(::Nothing)

### DIFF
--- a/src/repositories/contents.jl
+++ b/src/repositories/contents.jl
@@ -20,7 +20,6 @@ end
 
 Content(data::Dict) = json2github(Content, data)
 Content(path::AbstractString) = Content(Dict("path" => path))
-Content(::Nothing) = nothing
 
 namefield(content::Content) = content.path
 
@@ -75,6 +74,6 @@ content_uri(repo, path) = "/repos/$(name(repo))/contents/$(name(path))"
 function build_content_response(json::Dict)
     results = Dict()
     haskey(json, "commit") && setindex!(results, Commit(json["commit"]), "commit")
-    haskey(json, "content") && setindex!(results, Content(json["content"]), "content")
+    haskey(json, "content") && setindex!(results, isnothing(json["content"]) ? nothing : Content(json["content"]), "content")
     return results
 end

--- a/src/repositories/contents.jl
+++ b/src/repositories/contents.jl
@@ -20,6 +20,7 @@ end
 
 Content(data::Dict) = json2github(Content, data)
 Content(path::AbstractString) = Content(Dict("path" => path))
+Content(::Nothing) = nothing
 
 namefield(content::Content) = content.path
 


### PR DESCRIPTION
This adds `Content(::Nothing) = nothing`.

Otherwise `delete_file` throws a `MethodError`.

"MWE":
```julia
using GitHub, Base64

GitHub.Content(::Nothing) = nothing # without this line I get a MethodError when calling rm below

const AUTH = GitHub.authenticate(ENV["GITHUB_AUTH"])
const REPO = Repo("crstnbr/dqmc-benchmarks")

function push(filename; message="push $filename (api)")
    content = read(filename, String)
    d = Dict(
        "content" => base64encode(content),
        "message" => message
    )
    create_file(REPO, filename; auth=AUTH, params=d)
    nothing
end


function rm(filename; message="rm $filename (api)")
    d = Dict(
        "message" => message,
        "sha" => file(REPO, filename; auth=AUTH).sha
    )
    delete_file(REPO, filename; auth=AUTH, params=d)
    nothing
end

push("result.json")
rm("result.json")
```