### PR TITLE
Modified api_uri to support GitHub Enterprise installations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ julia:
     - 1.1
     - 1.2
     - 1.3
+    - 1.4
     - nightly
 notifications:
     email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GitHub"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
-version = "5.1.5"
+version = "5.1.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -507,3 +507,18 @@ end
 # Start the listener on localhost at port 8000
 GitHub.run(listener, IPv4(127,0,0,1), 8000)
 ```
+
+## GitHub Enterprise
+
+This library work with github.com, and also with self-hosted github, a.k.a. GitHub Enterprise. 
+
+To use it with self-hosted github, you need to create `GitHubWebAPI` structure and pass it to functions when needed.
+Following example shows obtaining repository info `private/Package.jl` on github instance with API `https://git.company.com/api/v3`.
+
+```julia
+import GitHub
+
+api = GitHub.GitHubWebAPI(HTTP.URI("https://git.company.com/api/v3"))
+myauth = GitHub.authenticate(api, ENV["GITHUB_AUTH"])
+myrepo = GitHub.repo(env, "private/Package.jl", auth=myauth)
+```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Here's a table of contents for this rather lengthy README:
 
 [5. Handling Webhook Events](#handling-webhook-events)
 
+[6. GitHub Enterprise](#github-enterprise)
+
 ## Response Types
 
 GitHub's JSON responses are parsed and returned to the caller as types of the form `G<:GitHub.GitHubType`. Here's some useful information about these types:

--- a/src/repositories/repositories.jl
+++ b/src/repositories/repositories.jl
@@ -20,6 +20,8 @@
     open_issues_count::Union{Int, Nothing}
     url::Union{HTTP.URI, Nothing}
     html_url::Union{HTTP.URI, Nothing}
+    clone_url::Union{HTTP.URI, Nothing}
+    ssh_url::Union{HTTP.URI, Nothing}
     homepage::Union{HTTP.URI, Nothing}
     pushed_at::Union{Dates.DateTime, Nothing}
     created_at::Union{Dates.DateTime, Nothing}

--- a/src/utils/requests.jl
+++ b/src/utils/requests.jl
@@ -40,7 +40,7 @@ end
 # Default API URIs #
 ####################
 
-api_uri(api::GitHubWebAPI, path) = merge(api.endpoint, path = path)
+api_uri(api::GitHubWebAPI, path) = merge(api.endpoint, path = api.endpoint.path * path)
 api_uri(api::GitHubAPI, path) = error("URI retrieval not implemented for this API type")
 
 #######################

--- a/test/ghtype_tests.jl
+++ b/test/ghtype_tests.jl
@@ -88,6 +88,7 @@ end
       "full_name": "octocat/Hello-World",
       "private": false,
       "url": "https://api.github.com/repos/octocat/Hello-World",
+      "ssh_url": "git@github.com:octocat/Hello-World.git",
       "language": null,
       "pushed_at": "2011-01-26T19:06:43Z",
       "permissions": {
@@ -118,6 +119,8 @@ end
         HTTP.URI(repo_json["url"]),
         nothing,
         nothing,
+        HTTP.URI(repo_json["ssh_url"]),
+        nothing,
         Dates.DateTime(chop(repo_json["pushed_at"])),
         nothing,
         nothing,
@@ -137,6 +140,7 @@ end
         full_name   = "octocat/Hello-World",
         private     = false,
         url         = "https://api.github.com/repos/octocat/Hello-World",
+        ssh_url     = "git@github.com:octocat/Hello-World.git",
         pushed_at   = "2011-01-26T19:06:43Z",
         permissions = Dict(
             "admin" => false,

--- a/test/read_only_api_tests.jl
+++ b/test/read_only_api_tests.jl
@@ -214,3 +214,10 @@ end
     exptag = tag(reponame, version; auth=auth)
     @test isa(exptag, Tag)
 end
+
+@testset "URI constructions" begin
+    public_gh = GitHub.DEFAULT_API
+    enterprise_gh = GitHubWebAPI(HTTP.URI("https://git.company.com/api/v3"))
+    @test api_uri(public_gh, "/rate_limit") == "https://api.github.com/rate_limit"
+    @test api_uri(enterprise_gh, "/rate_limit") == "https://git.company.com/api/v3/rate_limit"
+end

--- a/test/read_only_api_tests.jl
+++ b/test/read_only_api_tests.jl
@@ -217,7 +217,7 @@ end
 
 @testset "URI constructions" begin
     public_gh = GitHub.DEFAULT_API
-    enterprise_gh = GitHubWebAPI(HTTP.URI("https://git.company.com/api/v3"))
-    @test api_uri(public_gh, "/rate_limit") == "https://api.github.com/rate_limit"
-    @test api_uri(enterprise_gh, "/rate_limit") == "https://git.company.com/api/v3/rate_limit"
+    enterprise_gh = GitHub.GitHubWebAPI(HTTP.URI("https://git.company.com/api/v3"))
+    @test  GitHub.api_uri(public_gh, "/rate_limit") == "https://api.github.com/rate_limit"
+    @test  GitHub.api_uri(enterprise_gh, "/rate_limit") == "https://git.company.com/api/v3/rate_limit"
 end

--- a/test/read_only_api_tests.jl
+++ b/test/read_only_api_tests.jl
@@ -218,6 +218,6 @@ end
 @testset "URI constructions" begin
     public_gh = GitHub.DEFAULT_API
     enterprise_gh = GitHub.GitHubWebAPI(HTTP.URI("https://git.company.com/api/v3"))
-    @test  GitHub.api_uri(public_gh, "/rate_limit") == "https://api.github.com/rate_limit"
-    @test  GitHub.api_uri(enterprise_gh, "/rate_limit") == "https://git.company.com/api/v3/rate_limit"
+    @test  GitHub.api_uri(public_gh, "/rate_limit") == HTTP.URI("https://api.github.com/rate_limit")
+    @test  GitHub.api_uri(enterprise_gh, "/rate_limit") == HTTP.URI("https://git.company.com/api/v3/rate_limit")
 end


### PR DESCRIPTION
According to  [GitHub Enterprise Documentation](https://developer.github.com/enterprise/2.20/v3/) default endpoint is `http(s)://[hostname]/api/v3`. Currently, the suffix `/api/v3` gets lost during construction of URI, this PR fixes it. 

Since this library is used by both CompatHelper and RegistryCI, this small change will make integration  between both tools and GitHub Enterprise easier.

Solves #162 and #164 

Also adds Julia 1.4 to Travis CI tests, I think it's reasonable since nightly is already version 1.6.