### PR TITLE
Fix deprecated api endpoint

### DIFF
--- a/src/apps/installations.jl
+++ b/src/apps/installations.jl
@@ -16,7 +16,7 @@ requests to the installation `inst` on an organization or individual account.
 """
 @api_default function create_access_token(api::GitHubAPI, inst::Installation; auth::JWTAuth, headers = Dict(), options...)
     headers["Accept"] = "application/vnd.github.machine-man-preview+json"
-    payload = gh_post_json(api, "/installations/$(inst.id)/access_tokens", auth = auth,
+    payload = gh_post_json(api, "/app/installations/$(inst.id)/access_tokens", auth = auth,
         headers=headers, options...)
     OAuth2(payload["token"])
 end


### PR DESCRIPTION
Ref: https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/