### PR TITLE
Support secrets API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,11 +9,13 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+SodiumSeal = "2133526b-2bfb-4018-ac12-889fb3908a75"
 
 [compat]
 HTTP = "0.8, 0.9"
 JSON = "0.19, 0.20, 0.21"
 MbedTLS = "0.6, 0.7, 1"
+SodiumSeal = "0.1"
 julia = "0.7, 1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Here's a table that matches up the provided `GitHubType`s with their correspondi
 | `Blob`        | sha, e.g. `"95c8d1aa2a7b1e6d672e15b67e0df4abbe57dcbe"`            | [raw git blobs](https://developer.github.com/v3/git/blobs/)                                                                                                                                                   |
 | `Tree`        | sha, e.g. `"78e524d5e979e326a7c144ce195bf94ca9b04fa0"`            | [raw git trees](https://developer.github.com/v3/git/trees/)                                                                                                                                                   |
 | `Tag`         | tag name, e.g. `v1.0`                                             | [git tags](https://developer.github.com/v3/git/tags/)                                                                                                                                                         |
-| `References`  | reference name, e.g. `heads/master` (note: omits leading `refs/`) | [git tags](https://developer.github.com/v3/git/refs/)                                                                                                                                                         |
+| `References`  | reference name, e.g. `heads/master` (note: omits leading `refs/`) | [references](https://developer.github.com/v3/git/refs/)                                                                                                                                                         |
+| `Secrets`     | secret name, e.g. `TAGBOT_SECRET`                                 | [secrets](https://developer.github.com/v3/actions/secrets
+)                                                                                                                                                         |
 
 
 You can inspect which fields are available for a type `G<:GitHubType` by calling `fieldnames(G)`.
@@ -117,6 +119,7 @@ GitHub.jl implements a bunch of methods that make REST requests to GitHub's API.
 | `statuses(repo, ref)`                                    | `Tuple{Vector{Status}, Dict}`  | [get the statuses posted to `ref`](https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref)                            |
 | `status(repo, ref)`                                      | `Status`                       | [get the combined status for `ref`](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref)                 |
 | `create_webhook(owner, repo)`                            | `Webhook`                      | [create a webhook for `repo`](https://developer.github.com/v3/repos/hooks/#create-a-hook)                                                       |
+| `create_secret(repo, name)`                              | `Secret`                       | [create a secret for `repo`](https://developer.github.com/v3/actions/secrets/#create-or-update-a-repository-secret)                                                       |
 
 #### Pull Requests and Issues
 
@@ -513,7 +516,7 @@ GitHub.run(listener, IPv4(127,0,0,1), 8000)
 
 ## GitHub Enterprise
 
-This library work with github.com, and also with self-hosted github, a.k.a. GitHub Enterprise. 
+This library work with github.com, and also with self-hosted github, a.k.a. GitHub Enterprise.
 
 To use it with self-hosted github, you need to create `GitHubWebAPI` structure and pass it to functions when needed.
 Following example shows obtaining repository info `private/Package.jl` on github instance with API `https://git.company.com/api/v3`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ GitHub.jl implements a bunch of methods that make REST requests to GitHub's API.
 | `statuses(repo, ref)`                                    | `Tuple{Vector{Status}, Dict}`  | [get the statuses posted to `ref`](https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref)                            |
 | `status(repo, ref)`                                      | `Status`                       | [get the combined status for `ref`](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref)                 |
 | `create_webhook(owner, repo)`                            | `Webhook`                      | [create a webhook for `repo`](https://developer.github.com/v3/repos/hooks/#create-a-hook)                                                       |
-| `create_secret(repo, name)`                              | `Secret`                       | [create a secret for `repo`](https://developer.github.com/v3/actions/secrets/#create-or-update-a-repository-secret)                                                       |
+| `secrets(repo; auth)`                                    | `Tuple{Vector{Secret}, Dict}`  | [get names of all secrets for `repo`](https://developer.github.com/v3/actions/secrets/#list-repository-secrets)                                                       |
+| `secret(repo, name; auth)`                               | `Secret`                       | [get status of secret in `repo`](https://developer.github.com/v3/actions/secrets/#get-a-repository-secret)                                                       |
+| `create_secret(repo, name; value, auth)`                 | `nothing`                      | [create a secret for `repo`](https://developer.github.com/v3/actions/secrets/#create-or-update-a-repository-secret)                                                       |
+| `delete_secret(repo, name; auth)`                        | `nothing`                      | [delete a secret for `repo`](https://developer.github.com/v3/actions/secrets/#delete-a-repository-secret)                                                       |
 
 #### Pull Requests and Issues
 

--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -10,7 +10,8 @@ using Base64
 import HTTP,
        JSON,
        MbedTLS,
-       Sockets
+       Sockets,
+       SodiumSeal
 
 ########
 # init #
@@ -90,6 +91,7 @@ include("repositories/branches.jl")
 include("repositories/statuses.jl")
 include("repositories/webhooks.jl")
 include("repositories/deploykeys.jl")
+include("repositories/secrets.jl")
 
 # export -------
 
@@ -144,6 +146,13 @@ export # deploykeys.jl
        deploykeys,
        create_deploykey,
        delete_deploykey
+
+export # secrets.jl
+       Secret,
+       secret,
+       secrets,
+       create_secret,
+       delete_secret
 
 ##########
 # Issues #

--- a/src/repositories/secrets.jl
+++ b/src/repositories/secrets.jl
@@ -1,0 +1,76 @@
+################
+# Secrets Type #
+################
+
+@ghdef mutable struct Secret
+    name::Union{String, Nothing}
+    created_at::Union{Dates.DateTime, Nothing}
+    updated_at::Union{Dates.DateTime, Nothing}
+end
+
+Secret(name::AbstractString) = Secret(Dict("name" => name))
+
+namefield(secret::Secret) = secret.name
+
+##################
+# PublicKey Type #
+##################
+
+mutable struct PublicKey <: GitHubType
+    key_id::Union{String, Nothing}
+    key::Union{String, Nothing}
+end
+
+PublicKey(data::Dict) = json2github(PublicKey, data)
+
+namefield(key::PublicKey) = key.key
+
+function publickey(api::GitHubAPI, repo; options...)
+    result = gh_get_json(api, "/repos/$(name(repo))/actions/secrets/public-key"; options...)
+    return PublicKey(result)
+end
+
+###############
+# API Methods #
+###############
+
+@api_default function secret(api::GitHubAPI, repo, secret_obj; options...)
+    result = gh_get_json(api, "/repos/$(name(repo))/actions/secrets/$(name(secret_obj))"; options...)
+    return Secret(result)
+end
+
+@api_default function secrets(api::GitHubAPI, repo; options...)
+    results, page_data = gh_get_paged_json(api, "/repos/$(name(repo))/actions/secrets"; options...)
+    return map(Secret, results["secrets"]), page_data
+end
+
+@api_default function create_secret(api::GitHubAPI, repo, secretname; value, options...)
+    key = publickey(api, repo; options...)
+    k = SodiumSeal.KeyPair(key.key)
+    encrypted = SodiumSeal.seal(base64encode(value), k)
+    result = gh_put_json(api, "/repos/$(name(repo))/actions/secrets/$secretname"; params=Dict("encrypted_value"=>encrypted, "key_id"=>key.key_id), options...)
+    return nothing
+end
+
+@api_default function delete_secret(api::GitHubAPI, repo, secretname; options...)
+    return gh_delete(api, "/repos/$(name(repo))/actions/secrets/$(name(secretname))"; options...)
+end
+
+
+"""
+    secrets(repo; auth::Authorization) -> list::Vector{Secret}, page_data
+
+List the names of secrets for `repo`. Requires that you [`authenticate`](@ref).
+
+Secret values cannot be queried, only the names and the times of creation and most recent updates.
+"""
+secrets
+
+"""
+    create_secret(repo, name; value::String, auth::Authorization)
+
+Create GitHub Action secret `name` with value `value`. Requires that you [`authenticate`](@ref).
+
+`value` should be supplied as plain-text and will be encrypted via [libsodium](https://doc.libsodium.org/) for transmission.
+"""
+create_secret

--- a/src/repositories/secrets.jl
+++ b/src/repositories/secrets.jl
@@ -53,7 +53,8 @@ end
 end
 
 @api_default function delete_secret(api::GitHubAPI, repo, secretname; options...)
-    return gh_delete(api, "/repos/$(name(repo))/actions/secrets/$(name(secretname))"; options...)
+    gh_delete(api, "/repos/$(name(repo))/actions/secrets/$(name(secretname))"; options...)
+    return nothing
 end
 
 


### PR DESCRIPTION
Closes #159 

No tests because doing anything with secrets requires authentication. But I used it to successfully create a `DOCUMENTER_KEY` secret for any of my personal repos that lacked it.