### PR TITLE
fixed reference collection creation

### DIFF
--- a/src/git/reference.jl
+++ b/src/git/reference.jl
@@ -14,7 +14,7 @@ end
 
 @api_default function references(api::GitHubAPI, repo; options...)
     results, page_data = gh_get_paged_json(api, "/repos/$(name(repo))/git/refs"; options...)
-    return Reference.((results,)), page_data
+    return Reference.(results), page_data
 end
 
 @api_default function create_reference(api::GitHubAPI, repo; options...)


### PR DESCRIPTION
This patch fixes the following error in `GitHub.references` call
```
julia> refs = GitHub.references(repo)
ERROR: MethodError: no method matching Reference(::Vector{Any})
Closest candidates are:
  Reference(::Any, ::Any, ::Any) at /home/art/.julia/dev/GitHub/src/git/reference.jl:2
  Reference(; ref, url, object) at /home/art/.julia/dev/GitHub/src/utils/GitHubType.jl:48
  Reference(::Dict) at /home/art/.julia/dev/GitHub/src/utils/GitHubType.jl:49
  ...
Stacktrace:
  [1] _broadcast_getindex_evalf
    @ ./broadcast.jl:648 [inlined]
  [2] _broadcast_getindex
    @ ./broadcast.jl:621 [inlined]
  [3] (::Base.Broadcast.var"#19#20"{Base.Broadcast.Broadcasted{Base.Broadcast.Style{Tuple}, Nothing, Type{Reference}, Tuple{Tuple{Vector{Any}}}}})(k::Int64)
    @ Base.Broadcast ./broadcast.jl:1096
  [4] ntuple
    @ ./ntuple.jl:48 [inlined]
  [5] copy(bc::Base.Broadcast.Broadcasted{Base.Broadcast.Style{Tuple}, Nothing, Type{Reference}, Tuple{Tuple{Vector{Any}}}})
    @ Base.Broadcast ./broadcast.jl:1096
  [6] materialize
    @ ./broadcast.jl:883 [inlined]
  [7] references(api::GitHub.GitHubWebAPI, repo::Repo; options::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ GitHub ~/.julia/dev/GitHub/src/git/reference.jl:17
  [8] references
    @ ~/.julia/dev/GitHub/src/git/reference.jl:16 [inlined]
  [9] #references#335
    @ ./none:0 [inlined]
 [10] references(repo::Repo)
    @ GitHub ./none:0
 [11] top-level scope
    @ REPL[4]:1
```

Julia info:
```
julia> versioninfo()
Julia Version 1.6.0-beta1
Commit b84990e1ac (2021-01-08 12:42 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: AMD Phenom(tm) II X6 1090T Processor
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.0 (ORCJIT, amdfam10)
```