### PR TITLE
Wrap issue label API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Here's a table that matches up the provided `GitHubType`s with their correspondi
 | `Branch`      | name, e.g. `master`                                               | [repository branches](https://developer.github.com/v3/repos/#get-branch)                                                                                                                                      |
 | `Content`     | path, e.g. `"src/owners/owners.jl"`                               | [repository contents](https://developer.github.com/v3/repos/contents/)                                                                                                                                        |
 | `Comment`     | id, e.g. `162224613`                                              | [commit comments](https://developer.github.com/v3/repos/comments/), [issue comments](https://developer.github.com/v3/issues/comments/), [PR review comments](https://developer.github.com/v3/pulls/comments/) |
+| `Label`      | name, e.g. `bug`                                              | [issue labels](https://docs.github.com/en/rest/reference/issues#labels)
 | `Status`      | id, e.g. `366961773`                                              | [commit statuses](https://developer.github.com/v3/repos/statuses/)                                                                                                                                            |
 | `PullRequest` | number, e.g. `44`                                                 | [pull requests](https://developer.github.com/v3/pulls/)                                                                                                                                                       |
 | `Issue`       | number, e.g. `31`                                                 | [issues](https://developer.github.com/v3/issues/)                                                                                                                                                             |
@@ -171,6 +172,17 @@ GitHub.jl implements a bunch of methods that make REST requests to GitHub's API.
 | `delete_comment(repo, comment, :commit)` | `HTTP.Response`                | [delete the commit`comment` from `repo`](https://developer.github.com/v3/repos/comments/#delete-a-commit-comment)                                                    |
 | `delete_comment(repo, comment, :commit)` | `HTTP.Response`                | [delete the commit`comment` from `repo`](https://developer.github.com/v3/repos/comments/#delete-a-commit-comment)                                                    |
 | `reply_to(repo, review, comment, body)`  | `HTTP.Response`                | [reply to the `comment` (of `review` in `repo`) creating a new comment with the specified `body`](https://developer.github.com/v3/pulls/comments/#alternative-input) |
+
+#### Labels
+
+
+| method                                   | return type                    | documentation                                                                                                                                                        |
+|------------------------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `labels(repo,issue)`         | `Vector{Label}`                      | [list labels from `issue`](https://docs.github.com/en/rest/reference/issues#list-labels-for-an-issue)                                                          |
+| `add_labels(repo, issue, labels)`            | `Vector{Label}`                      | [add labels to an `issue`](https://docs.github.com/en/rest/reference/issues#add-labels-to-an-issue)                                                              |
+| `set_labels(repo, issue, labels)`        | `Vector{Label}`                      | [set the labels for an `issue`](https://docs.github.com/en/rest/reference/issues#set-labels-for-an-issue) 
+| `remove_all_labels(repo, issue)`        | `HTTP.Response`                      | [remove all labels from an `issue`](https://docs.github.com/en/rest/reference/issues#remove-all-labels-from-an-issue) 
+| `remove_label(repo, issue, label)`        | `HTTP.Response`                      | [remove a label from an `issue`](https://docs.github.com/en/rest/reference/issues#remove-a-label-from-an-issue)
 
 #### Social Activity
 

--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -181,6 +181,7 @@ include("issues/pull_requests.jl")
 include("issues/issues.jl")
 include("issues/comments.jl")
 include("issues/reviews.jl")
+include("issues/labels.jl")
 
 # export -------
 
@@ -217,6 +218,13 @@ export # reviews.jl
        reply_to,
        dismiss_review
 
+export # labels.jl
+       Label,
+       labels,
+       add_labels,
+       set_labels,
+       remove_all_labels,
+       remove_label
 
 #########
 # Gists #

--- a/src/issues/labels.jl
+++ b/src/issues/labels.jl
@@ -1,0 +1,38 @@
+@ghdef mutable struct Label
+    name::Union{String, Nothing}
+    default::Union{Bool, Nothing}
+    id::Union{Int, Nothing}
+    color::Union{String, Nothing}
+    node_id::Union{String, Nothing}
+    url::Union{String, Nothing}
+    description::Union{String, Nothing}
+end
+
+namefield(label::Label) = label.name
+
+Label(name::AbstractString) = Label(Dict("name" => name))
+
+@api_default function labels(api::GitHubAPI, repo, issue; options...)
+    result = gh_get_json(api, "/repos/$(name(repo))/issues/$(name(issue))/labels"; options...)
+    return Label.(result)
+end
+
+@api_default function add_labels(api::GitHubAPI, repo, issue, labels; options...)
+    params = Dict("labels" => name.(labels))
+    result = gh_post_json(api, "/repos/$(name(repo))/issues/$(name(issue))/labels"; params, options...)
+    return Label.(result)
+end
+
+@api_default function set_labels(api::GitHubAPI, repo, issue, labels; options...)
+    params = Dict("labels" => name.(labels))
+    result = gh_put_json(api, "/repos/$(name(repo))/issues/$(name(issue))/labels"; params, options...)
+    return Label.(result)
+end
+
+@api_default function remove_all_labels(api::GitHubAPI, repo, issue; options...)
+    return gh_delete(api, "/repos/$(name(repo))/issues/$(name(issue))/labels"; options...)
+end
+
+@api_default function remove_label(api::GitHubAPI, repo, issue, label; options...)
+    return gh_delete(api, "/repos/$(name(repo))/issues/$(name(issue))/labels/$(name(label))"; options...)
+end

--- a/src/issues/labels.jl
+++ b/src/issues/labels.jl
@@ -18,14 +18,14 @@ Label(name::AbstractString) = Label(Dict("name" => name))
 end
 
 @api_default function add_labels(api::GitHubAPI, repo, issue, labels; options...)
-    params = Dict("labels" => name.(labels))
-    result = gh_post_json(api, "/repos/$(name(repo))/issues/$(name(issue))/labels"; params, options...)
+    result = gh_post_json(api, "/repos/$(name(repo))/issues/$(name(issue))/labels";
+                          params=Dict("labels" => name.(labels)), options...)
     return Label.(result)
 end
 
 @api_default function set_labels(api::GitHubAPI, repo, issue, labels; options...)
-    params = Dict("labels" => name.(labels))
-    result = gh_put_json(api, "/repos/$(name(repo))/issues/$(name(issue))/labels"; params, options...)
+    result = gh_put_json(api, "/repos/$(name(repo))/issues/$(name(issue))/labels";
+                         params=Dict("labels" => name.(labels)), options...)
     return Label.(result)
 end
 

--- a/test/ghtype_tests.jl
+++ b/test/ghtype_tests.jl
@@ -305,6 +305,35 @@ end
     test_show(comment_result)
 end
 
+@testset "Label" begin
+    label_json = JSON.parse(
+        """
+        {
+            "id": 208045946,
+            "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
+            "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+            "name": "bug",
+            "description": "Something isn't working",
+            "color": "f29513",
+            "default": true
+          }
+        """
+    )
+
+    label_result = Label(String(label_json["name"]),
+                         Bool(label_json["default"]),
+                         Int(label_json["id"]),
+                         String(label_json["color"]),
+                         String(label_json["node_id"]),
+                         String(label_json["url"]),
+                         String(label_json["description"]))
+
+    
+    @test Label(label_json) == label_result
+    @test name(Label(label_json["name"])) == name(label_result)
+    test_show(label_result)
+end
+
 @testset "Content" begin
     content_json = JSON.parse(
     """


### PR DESCRIPTION
This wraps the issue label API, i.e. the first 5 commands from https://docs.github.com/en/rest/reference/issues#labels. I decided to leave the repo-level ones for future work.

I tested these here: https://github.com/ericphanson/VisualStringDistances.jl/pull/14

In service of https://github.com/JuliaRegistries/Registrator.jl/issues/308