### PR TITLE
Add check for null request body

### DIFF
--- a/src/activity/events.jl
+++ b/src/activity/events.jl
@@ -191,6 +191,10 @@ function handle_comment(handle, event::WebhookEvent, auth::Authorization,
         end
     end
 
+    if body_container["body"] === nothing
+        return HTTP.Response(204, "trigger match not found")
+    end
+
     trigger_match = match(trigger, body_container["body"])
 
     if trigger_match === nothing


### PR DESCRIPTION
For bot events, sometimes the value for the "body" key in the request is `null` (`nothing`):
![null_body](https://user-images.githubusercontent.com/2999399/178334031-8e5eb64e-a848-416c-9e2e-c43af9db14d6.png)

This causes the subsequent `match` method to error out. Added a check for `nothing` here.

