### PR TITLE
Simplify usage of Content/Blob's base64-encoded data.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GitHub"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
-version = "5.8.1"
+version = "5.8.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/git/blob.jl
+++ b/src/git/blob.jl
@@ -1,3 +1,7 @@
+################
+# Blob Type #
+################
+
 @ghdef mutable struct Blob
     content::Union{String, Nothing}
     encoding::Union{String, Nothing}
@@ -9,6 +13,15 @@ end
 Blob(sha::AbstractString) = Blob(Dict("sha" => sha))
 
 namefield(blob::Blob) = blob.sha
+
+function Base.String(blob::Blob)
+    @assert blob.encoding == "base64"
+    String(base64decode(blob.content))
+end
+
+###############
+# API Methods #
+###############
 
 @api_default function blob(api::GitHubAPI, repo, blob_obj; options...)
     result = gh_get_json(api, "/repos/$(name(repo))/git/blobs/$(name(blob_obj))"; options...)

--- a/src/repositories/contents.jl
+++ b/src/repositories/contents.jl
@@ -23,6 +23,11 @@ Content(path::AbstractString) = Content(Dict("path" => path))
 
 namefield(content::Content) = content.path
 
+function Base.String(content::Content)
+    @assert content.encoding == "base64"
+    String(base64decode(content.content))
+end
+
 ###############
 # API Methods #
 ###############

--- a/test/read_only_api_tests.jl
+++ b/test/read_only_api_tests.jl
@@ -91,6 +91,7 @@ end
     @test readme_permalink == "https://github.com/JuliaWeb/GitHub.jl/blob/$(test_sha)/README.md"
     @test owners_permalink == "https://github.com/JuliaWeb/GitHub.jl/tree/$(test_sha)/src/owners"
     @test readme_file == readme(ghjl; auth = auth)
+    @test occursin("GitHub.jl", String(readme_file))
     @test hasghobj("src/GitHub.jl", src_dir)
 
     # test GitHub.status, GitHub.statuses

--- a/test/read_only_api_tests.jl
+++ b/test/read_only_api_tests.jl
@@ -226,7 +226,7 @@ end
             @test entry["type"] == "blob"
 
             b = blob(github_jl, entry["sha"]; auth=auth)
-            @test occursin("GitHub.jl", String(base64decode(replace(b.content,"\n" => ""))))
+            @test occursin("GitHub.jl", String(b))
 
             break
         end


### PR DESCRIPTION
Currently, the `.contents` field only contains base64-encoded data, which isn't very useful.