### PR TITLE
Look through lightweight tags pointing to annotated tags.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GitHub"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
-version = "5.8.1"
+version = "5.8.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/read_only_api_tests.jl
+++ b/test/read_only_api_tests.jl
@@ -240,10 +240,17 @@ end
     @test ref.object["type"] == "commit"
 
     # Tag API
-    reponame = "QuantEcon/Expectations.jl"
-    version = "v1.0.1"
+    reponame = "JuliaGPU/Adapt.jl"
+    ## lightweight tag
+    version = "v0.1.0"
     exptag = tag(reponame, version; auth=auth)
     @test isa(exptag, Tag)
+    @test exptag.object["type"] == "commit"
+    ## lightweight tag pointing to an annotated tag (should return the annotated tag)
+    version = "v3.4.0"
+    exptag = tag(reponame, version; auth=auth)
+    @test isa(exptag, Tag)
+    @test exptag.object["type"] == "commit"
 end
 
 @testset "URI constructions" begin


### PR DESCRIPTION
Git has two kinds of tags, simple lightweight ones (pointing to a commit):

```
julia> GitHub.tag("JuliaGPU/Adapt.jl", "v0.1.0")
Tag (all fields are Union{Nothing, T}):
  url: URI("https://api.github.com/repos/JuliaGPU/Adapt.jl/git/refs/tags/v0.1.0")
  object: Dict{String, Any}("sha"=>"87ba4fab1f6f87b6b3662e5aa217b0db1937f2a3", "type"=>"commit", "url"=>"https://api.github.com/repos/JuliaGPU/Adapt.jl/git/commits/87ba4fab1f6f87b6b3662e5aa217b0db1937f2a3")
```

And annotated ones, which are represented by a lightweight tag that points at the annotated tag object:

```
julia> GitHub.tag("JuliaGPU/Adapt.jl", "v3.4.0")
Tag (all fields are Union{Nothing, T}):
  url: URI("https://api.github.com/repos/JuliaGPU/Adapt.jl/git/refs/tags/v3.4.0")
  object: Dict{String, Any}("sha"=>"4ce0acfdc40d91d9a6198df344a2f9c64c483be5", "type"=>"tag", "url"=>"https://api.github.com/repos/JuliaGPU/Adapt.jl/git/tags/4ce0acfdc40d91d9a6198df344a2f9c64c483be5")
```

This is confusing, as the SHA returned here cannot be treated as a commit SHA. Furthermore,  it's impossible right now to look up the underlying annotated tag, as the request needs to go to `repo/git/tags` and not `repo/git/refs/tags` (so we can't just call `GitHub.tag` a second time).

Instead, I'm opting here to have the `tag` and `tags` function automatically peek through lightweight tags that point to an annotated tags, thus always returning an object which should contain a commit object (which is probably what you want anyway):

```
julia> GitHub.tag("JuliaGPU/Adapt.jl", "v3.4.0")
Tag (all fields are Union{Nothing, T}):
  tag: "v3.4.0"
  sha: "4ce0acfdc40d91d9a6198df344a2f9c64c483be5"
  url: URI("https://api.github.com/repos/JuliaGPU/Adapt.jl/git/tags/4ce0acfdc40d91d9a6198df344a2f9c64c483be5")
  message: "## Adapt v3.4.0\n\n[Diff since v3.3.3](https://github.com/JuliaGPU/Adapt.jl/compare/v3.3.3...v3.4.0)\n\n\n\n**Merged pull requests:**\n- Improve typestability. (#53) (@N5N3)"
  tagger: Dict{String, Any}("name"=>"github-actions[bot]", "date"=>"2022-07-28T22:07:47Z", "email"=>"41898282+github-actions[bot]@users.noreply.github.com")
  object: Dict{String, Any}("sha"=>"4c07cccd182bd36a7cbb288d64c8281dd7be665d", "type"=>"commit", "url"=>"https://api.github.com/repos/JuliaGPU/Adapt.jl/git/commits/4c07cccd182bd36a7cbb288d64c8281dd7be665d")
  verification: Dict{String, Any}("signature"=>nothing, "payload"=>nothing, "reason"=>"unsigned", "verified"=>false)
```

If for some reason you really need the SHA of the annotated tag, it's still there in the `tag.sha` object (note how that SHA is different from the `tag.object["sha"]`).