### PR TITLE
Give a better error message if token contains newlines

### DIFF
--- a/src/utils/auth.jl
+++ b/src/utils/auth.jl
@@ -7,6 +7,13 @@ abstract type Authorization end
 # TODO: SecureString on 0.7
 struct OAuth2 <: Authorization
     token::String
+    function OAuth2(token)
+        token = convert(String, token)
+        if !all(c->isascii(c) && !isspace(c), token)
+            throw(ArgumentError("token `$token` has invalid whitespace or non-ascii character."))
+        end
+        new(token)
+    end
 end
 
 struct UsernamePassAuth <: Authorization
@@ -18,6 +25,13 @@ struct AnonymousAuth <: Authorization end
 
 struct JWTAuth <: Authorization
     JWT::String
+    function JWTAuth(token)
+        token = convert(String, token)
+        if !all(c->isascii(c) && !isspace(c), token)
+            throw(ArgumentError("ArgumentError token `$token` has invalid whitespace or non-ascii character."))
+        end
+        new(token)
+    end
 end
 
 ####################

--- a/test/auth_tests.jl
+++ b/test/auth_tests.jl
@@ -21,3 +21,6 @@ auth2 = GitHub.JWTAuth(1234, key; iat = DateTime("2016-9-15T14:00"))
 # test to make sure things don't break.
 @test auth.JWT == correct_jwt
 @test auth2.JWT == correct_jwt
+
+@test_throws ArgumentError GitHub.OAuth2("ghp_\n")
+@test_throws ArgumentError GitHub.JWTAuth("ghp_\n")


### PR DESCRIPTION
I constructed a token as `OAuth2(read("token", String))`, but my token file had a trailing newline. GitHub stops parsing headers after an empty line, so depending on where the header ended up in the list of headers, this was causing all sorts of strange errors. Detect this situation and throw an intelligent error in GitHub.jl instead.