### PR TITLE
Require HTTP.jl v1.10.17 and URIs.jl v1.6, and require Julia 1.6+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'  # automatically expands to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 HTTP = "1.10.17" # Must be >= 1.10.17, see https://github.com/JuliaWeb/GitHub.jl/pull/225
-URIs = "1.1"
+URIs = "1.6"  # Must be >= 1.6, see https://github.com/JuliaWeb/GitHub.jl/pull/225
 JSON = "0.19, 0.20, 0.21"
 MbedTLS = "0.6, 0.7, 1"
 SodiumSeal = "0.1"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SodiumSeal = "2133526b-2bfb-4018-ac12-889fb3908a75"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
-HTTP = "0.9, 1"
+HTTP = "1.10.17" # Must be >= 1.10.17, see https://github.com/JuliaWeb/GitHub.jl/pull/225
 URIs = "1.1"
 JSON = "0.19, 0.20, 0.21"
 MbedTLS = "0.6, 0.7, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ URIs = "1.6"  # Must be >= 1.6, see https://github.com/JuliaWeb/GitHub.jl/pull/2
 JSON = "0.19, 0.20, 0.21"
 MbedTLS = "0.6, 0.7, 1"
 SodiumSeal = "0.1"
-julia = "0.7, 1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GitHub"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
-version = "5.9.1"
+version = "5.10.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
We need HTTP v1.10.17 in order to get https://github.com/JuliaWeb/HTTP.jl/pull/1225, which in turn gives us https://github.com/JuliaWeb/URIs.jl/pull/66.

And we need URIs v1.6 in order to get https://github.com/JuliaWeb/URIs.jl/pull/66.