### PR TITLE
fix compare tests

### DIFF
--- a/test/read_only_api_tests.jl
+++ b/test/read_only_api_tests.jl
@@ -86,7 +86,7 @@ end
     @test hasghobj("master", first(branches(ghjl; auth = auth)))
 
     # test GitHub.compare
-    # check if the latest commit it a merge commit
+    # check if the latest commit is a merge commit
     latest_commit = GitHub.branch(ghjl, "master"; auth=auth).commit
     is_latest_commit_merge = length(latest_commit.parents) > 1
     if is_latest_commit_merge

--- a/test/read_only_api_tests.jl
+++ b/test/read_only_api_tests.jl
@@ -86,10 +86,21 @@ end
     @test hasghobj("master", first(branches(ghjl; auth = auth)))
 
     # test GitHub.compare
-    @test compare(ghjl, "master", "master~"; auth = auth).behind_by == 1
-    let comparison = compare(ghjl, "master~", "master"; auth = auth)
-        @test comparison.ahead_by == 1
-        @test length(comparison.commits) == 1
+    # check if the latest commit it a merge commit
+    latest_commit = GitHub.branch(ghjl, "master"; auth=auth).commit
+    is_latest_commit_merge = length(latest_commit.parents) > 1
+    if is_latest_commit_merge
+        @test compare(ghjl, "master", "master~"; auth = auth).behind_by >= 1
+        let comparison = compare(ghjl, "master~", "master"; auth = auth)
+            @test comparison.ahead_by >= 1
+            @test length(comparison.commits) >= 1
+        end
+    else
+        @test compare(ghjl, "master", "master~"; auth = auth).behind_by == 1
+        let comparison = compare(ghjl, "master~", "master"; auth = auth)
+            @test comparison.ahead_by == 1
+            @test length(comparison.commits) == 1
+        end
     end
 
     # test GitHub.file, GitHub.directory, GitHub.readme, GitHub.permalink


### PR DESCRIPTION
The compare tests failed if the commits on master branch were merge commits. This fixes the tests by checking the latest commit on master branch and changing the test conditions accordingly.

fixes  #228